### PR TITLE
fix: point to main branch for the examples

### DIFF
--- a/banners/ekscluster.md
+++ b/banners/ekscluster.md
@@ -2,5 +2,5 @@
 
 This document explains the full schema for the `kind: EKSCluster` for the `furyctl.yaml` file used by `furyctl`. This configuration file will be used to deploy a Kubernetes Fury Cluster deployed through AWS's Elastic Kubernetes Service.
 
-An example file can be found [here](https://github.com/sighupio/fury-distribution/blob/feature/schema-docs/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl).
+An example file can be found [here](https://github.com/sighupio/fury-distribution/blob/main/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl).
 

--- a/banners/kfddistribution.md
+++ b/banners/kfddistribution.md
@@ -2,5 +2,5 @@
 
 This document explains the full schema for the `kind: KFDDistribution` for the `furyctl.yaml` file used by `furyctl`. This configuration file will be used to deploy the Kubernetes Fury Distribution modules on top of an existing Kubernetes cluster.
 
-An example file can be found [here](https://github.com/sighupio/fury-distribution/blob/feature/schema-docs/templates/config/kfddistribution-kfd-v1alpha2.yaml.tpl).
+An example file can be found [here](https://github.com/sighupio/fury-distribution/blob/main/templates/config/kfddistribution-kfd-v1alpha2.yaml.tpl).
 

--- a/banners/onpremises.md
+++ b/banners/onpremises.md
@@ -2,5 +2,5 @@
 
 This document explains the full schema for the `kind: OnPremises` for the `furyctl.yaml` file used by `furyctl`. This configuration file will be used to deploy the Kubernetes Fury Distribution modules and cluster on premises.
 
-An example file can be found [here](https://github.com/sighupio/fury-distribution/blob/feature/schema-docs/templates/config/onpremises-kfd-v1alpha2.yaml.tpl).
+An example file can be found [here](https://github.com/sighupio/fury-distribution/blob/main/templates/config/onpremises-kfd-v1alpha2.yaml.tpl).
 


### PR DESCRIPTION
Point to main branch for the examples configuration files in the banners instead of a custom branch.